### PR TITLE
Fixing broken links in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Minify files with UglifyJS.
 
-_Note that this plugin has not yet been released, and only works with the latest bleeding-edge, in-development version of grunt. See the [When will I be able to use in-development feature 'X'?](https://github.com/gruntjs/grunt/blob/devel/docs/faq.md#when-will-i-be-able-to-use-in-development-feature-x) FAQ entry for more information._
+_Note that this plugin has not yet been released, and only works with the latest bleeding-edge, in-development version of grunt. See the [When will I be able to use in-development feature 'X'?](https://github.com/gruntjs/grunt/wiki/Frequently-Asked-Questions#faq-devel) FAQ entry for more information._
 
 ## Getting Started
 If you haven't used [grunt][] before, be sure to check out the [Getting Started][] guide, as it explains how to create a [gruntfile][Getting Started] as well as install and use grunt plugins. Once you're familiar with that process, install this plugin with this command:
@@ -12,7 +12,7 @@ npm install grunt-contrib-uglify --save-dev
 ```
 
 [grunt]: http://gruntjs.com/
-[Getting Started]: https://github.com/gruntjs/grunt/blob/devel/docs/getting_started.md
+[Getting Started]: https://github.com/gruntjs/grunt/wiki/Getting-started
 
 
 ## Uglify task
@@ -30,50 +30,50 @@ This task primarily delegates to [UglifyJS2][], so please consider the [UglifyJS
 [UglifyJS documentation]: http://lisperator.net/uglifyjs/
 
 #### mangle
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `{}`
 
 Turn on or off mangling with default options. If an `Object` is specified, it is passed directly to `ast.mangle_names()` *and* `ast.compute_char_frequency()` (mimicking command line behavior).
 
 #### compress
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `{}`
 
 Turn on or off source compression with default options. If an `Object` is specified, it is passed as options to `UglifyJS.Compressor()`.
 
 #### beautify
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `false`
 
 Turns on beautification of the generated source code. An `Object` will be merged and passed with the options sent to `UglifyJS.OutputStream()`.
 
 #### sourceMap
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 Specify the location to output the source map.
 
 #### sourceMapRoot
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location where your source files can be found.
 
 #### sourceMapIn
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location of an input source map from an earlier compilation, e.g. from CoffeeScript.
 
 #### sourceMappingURL
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location of your sourcemap. Defaults to the location you use for sourceMap, override if you need finer control
 
 #### preserveComments
-Type: `Boolean` `String` `Function`  
-Default: `undefined`  
+Type: `Boolean` `String` `Function`
+Default: `undefined`
 Options: `false` `'all'` `'some'`
 
 Turn on preservation of comments.
@@ -84,14 +84,14 @@ Turn on preservation of comments.
 - `Function` specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either `true` or `false`
 
 #### banner
-Type: `String`  
+Type: `String`
 Default: empty string
 
 This string will be prepended to the beginning of the minified output. It is processed using [grunt.template.process][], using the default options.
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
-[grunt.template.process]: https://github.com/gruntjs/grunt/blob/devel/docs/api_template.md#grunttemplateprocess
+[grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#wiki-grunt-template-process
 
 ### Usage examples
 


### PR DESCRIPTION
Changed broken links to *.md files, which are removed from the repo, to point to the wiki
