### PR TITLE
Fixed broken links in project documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,50 +30,50 @@ This task primarily delegates to [UglifyJS2][], so please consider the [UglifyJS
 [UglifyJS documentation]: http://lisperator.net/uglifyjs/
 
 #### mangle
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `{}`
 
 Turn on or off mangling with default options. If an `Object` is specified, it is passed directly to `ast.mangle_names()` *and* `ast.compute_char_frequency()` (mimicking command line behavior).
 
 #### compress
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `{}`
 
 Turn on or off source compression with default options. If an `Object` is specified, it is passed as options to `UglifyJS.Compressor()`.
 
 #### beautify
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `false`
 
 Turns on beautification of the generated source code. An `Object` will be merged and passed with the options sent to `UglifyJS.OutputStream()`.
 
 #### sourceMap
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 Specify the location to output the source map.
 
 #### sourceMapRoot
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location where your source files can be found.
 
 #### sourceMapIn
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location of an input source map from an earlier compilation, e.g. from CoffeeScript.
 
 #### sourceMappingURL
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location of your sourcemap. Defaults to the location you use for sourceMap, override if you need finer control
 
 #### preserveComments
-Type: `Boolean` `String` `Function`  
-Default: `undefined`  
+Type: `Boolean` `String` `Function`
+Default: `undefined`
 Options: `false` `'all'` `'some'`
 
 Turn on preservation of comments.
@@ -84,14 +84,14 @@ Turn on preservation of comments.
 - `Function` specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either `true` or `false`
 
 #### banner
-Type: `String`  
+Type: `String`
 Default: empty string
 
 This string will be prepended to the beginning of the minified output. It is processed using [grunt.template.process][], using the default options.
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
-[grunt.template.process]: https://github.com/gruntjs/grunt/blob/devel/docs/api_template.md#grunttemplateprocess
+[grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#wiki-grunt-template-process
 
 ### Usage examples
 
@@ -264,10 +264,10 @@ grunt.initConfig({
 
 ## Release History
 
- * 2012-11-27   v0.1.0   Work in progress, not yet officially released.
+ * 2012-11-28   v0.1.0   Work in progress, not yet officially released.
 
 ---
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com)
 
-*This file was generated on Thu Dec 13 2012 15:42:18.*
+*This file was generated on Sat Dec 29 2012 22:18:20.*

--- a/docs/uglify-options.md
+++ b/docs/uglify-options.md
@@ -6,50 +6,50 @@ This task primarily delegates to [UglifyJS2][], so please consider the [UglifyJS
 [UglifyJS documentation]: http://lisperator.net/uglifyjs/
 
 ## mangle
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `{}`
 
 Turn on or off mangling with default options. If an `Object` is specified, it is passed directly to `ast.mangle_names()` *and* `ast.compute_char_frequency()` (mimicking command line behavior).
 
 ## compress
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `{}`
 
 Turn on or off source compression with default options. If an `Object` is specified, it is passed as options to `UglifyJS.Compressor()`.
 
 ## beautify
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `false`
 
 Turns on beautification of the generated source code. An `Object` will be merged and passed with the options sent to `UglifyJS.OutputStream()`.
 
 ## sourceMap
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 Specify the location to output the source map.
 
 ## sourceMapRoot
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location where your source files can be found.
 
 ## sourceMapIn
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location of an input source map from an earlier compilation, e.g. from CoffeeScript.
 
 ## sourceMappingURL
-Type: `String`  
+Type: `String`
 Default: `undefined`
 
 The location of your sourcemap. Defaults to the location you use for sourceMap, override if you need finer control
 
 ## preserveComments
-Type: `Boolean` `String` `Function`  
-Default: `undefined`  
+Type: `Boolean` `String` `Function`
+Default: `undefined`
 Options: `false` `'all'` `'some'`
 
 Turn on preservation of comments.
@@ -60,11 +60,11 @@ Turn on preservation of comments.
 - `Function` specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either `true` or `false`
 
 ## banner
-Type: `String`  
+Type: `String`
 Default: empty string
 
 This string will be prepended to the beginning of the minified output. It is processed using [grunt.template.process][], using the default options.
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
-[grunt.template.process]: https://github.com/gruntjs/grunt/blob/devel/docs/api_template.md#grunttemplateprocess
+[grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#wiki-grunt-template-process


### PR DESCRIPTION
Fixed broken link in `docs/uglify-options.md` to point to the wiki instead of the removed *.md files in the grunt repo (This time it's done on the right spot :-) The README.md had been generated with the included grunt task.
