### PR TITLE
Better error reporting from uglify

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
     try {
       result = uglify.minify(files, this.file.dest, options);
     } catch(e) {
-      grunt.log.error(e);
+      grunt.log.error(e.msg || e);
       grunt.fail.warn('uglification failed!');
     }
 


### PR DESCRIPTION
Uglify's `DefaultsError` doesn't have a useful `toString`, picking up the `msg` property makes for better errors in grunt
