### PR TITLE
package now exports internal libraries for re-use

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/gruntjs/grunt-contrib-uglify/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "Gruntfile.js",
+  "main": "tasks/uglify.js",
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -14,6 +14,15 @@ module.exports = function(grunt) {
   var uglify = require('./lib/uglify').init(grunt);
   var minlib = require('./lib/min').init(grunt);
 
+  // if grunt is not provided, then expose internal API
+  if ('object' !== typeof(grunt)) {
+    return {
+      // re-require so libs can be re-initted.
+      uglify: require('./lib/uglify'),
+      minlib: require('./lib/min')
+    };
+  }
+
   grunt.registerMultiTask('uglify', 'Minify files with UglifyJS.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({


### PR DESCRIPTION
I understand this is a stretch, i needed the functionality so i did it.

Generally that's the pattern i follow to export my grunt plugins as standalone npm libraries.

You mentioned something about separating task logic from library payload in your grunt 0.4 mass issue creation... where is that?
