### PR TITLE
Add support for enclose option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,20 @@ module.exports = function(grunt) {
           beautify: true
         }
       },
+      enclose: {
+        files: {
+          'tmp/enclose.js': ['test/fixtures/src/simple.js']
+        },
+        options: {
+          beautify: true,
+          compress: false,
+          enclose: {
+            'window.argA': 'paramA',
+            'window.argB': 'paramB'
+          },
+          mangle: false
+        }
+      },
       multifile: {
         files: {
           'tmp/multifile.js': ['test/fixtures/src/simple.js','test/fixtures/src/comments.js']

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Default: `undefined`
 
 The number of directories to drop from the path prefix when declaring files in the source map.
 
+#### enclose
+Type: `Object`
+Default: `undefined`
+
+Wrap all of the code in a closure with a configurable arguments/parameters list.
+Each key-value pair in the `enclose` object is effectively an argument-parameter pair.
+
 #### wrap
 Type: `String`
 Default: `undefined`

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -47,6 +47,15 @@ exports.init = function(grunt) {
       topLevel = topLevel.wrap_commonjs(options.wrap, options.exportAll);
     }
 
+    // Wrap code in closure with configurable arguments/parameters list.
+    if (options.enclose) {
+      var argParamList = grunt.util._.map(options.enclose, function(val, key) {
+        return key + ':' + val;
+      });
+
+      topLevel = topLevel.wrap_enclose(argParamList);
+    }
+
     // Need to call this before we mangle or compress,
     // and call after any compression or ast altering
     topLevel.figure_out_scope();

--- a/test/fixtures/expected/enclose.js
+++ b/test/fixtures/expected/enclose.js
@@ -1,0 +1,8 @@
+(function(paramA, paramB) {
+    var longNameA = 1;
+    var longNameB = 2;
+    function longFunctionC(argumentC, argumentD) {
+        return longNameA + longNameB + argumentC + argumentD;
+    }
+    var result = longFunctionC(3, 4);
+})(window.argA, window.argB);

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -15,6 +15,7 @@ exports.contrib_uglify = {
       'compress_mangle_beautify.js',
       'compress_mangle_except.js',
       'compress_mangle_sourcemap',
+      'enclose.js',
       'sourcemapurl.js',
       'multifile.js',
       'wrap.js',


### PR DESCRIPTION
I recently had a [pull request](https://github.com/mishoo/UglifyJS2/issues/139) accepted by Uglify that adds support for wrapping code in a closure with a configurable arguments/parameters list. Now grunt-contrib-uglify supports it too :smile: 

Assuming everything looks good, you'll want to hold off on merging this until the next Uglify release happens.
