### PR TITLE
Updated to new sourceMappingURL syntax

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -77,7 +77,7 @@ exports.init = function(grunt) {
     var min = output.get();
 
     if (options.sourceMappingURL || options.sourceMap) {
-      min += "\n/*\n//@ sourceMappingURL=" + (options.sourceMappingURL || options.sourceMap) + "\n*/";
+      min += "\n//# sourceMappingURL=" + (options.sourceMappingURL || options.sourceMap) + "\n";
     }
 
     var result = {

--- a/test/fixtures/expected/multiple_sourcemaps1.js
+++ b/test/fixtures/expected/multiple_sourcemaps1.js
@@ -1,4 +1,2 @@
 function longFunctionC(n,o){return longNameA+longNameB+n+o}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-/*
-//@ sourceMappingURL=test/fixtures/expected/multiple_sourcemaps1.mapurl
-*/
+//# sourceMappingURL=test/fixtures/expected/multiple_sourcemaps1.mapurl

--- a/test/fixtures/expected/multiple_sourcemaps2.js
+++ b/test/fixtures/expected/multiple_sourcemaps2.js
@@ -1,4 +1,2 @@
 function foo(){return 42}function bar(){return 2*foo()}function baz(){return bar()*bar()}
-/*
-//@ sourceMappingURL=test/fixtures/expected/multiple_sourcemaps2.mapurl
-*/
+//# sourceMappingURL=test/fixtures/expected/multiple_sourcemaps2.mapurl

--- a/test/fixtures/expected/sourcemapin.js
+++ b/test/fixtures/expected/sourcemapin.js
@@ -1,4 +1,2 @@
 void function(){var cubes,list,math,number,opposite,race,square;number=42,opposite=!0,opposite&&(number=-42),square=function(x){return x*x},list=[1,2,3,4,5],math={root:Math.sqrt,square:square,cube:function(x){return x*square(x)}},race=function(winner,runners){return runners=arguments.length>=2?[].slice.call(arguments,1):[],print(winner,runners)},"undefined"!=typeof elvis&&null!=elvis&&alert("I knew it!"),cubes=function(accum$){for(var num,i$=0,length$=list.length;length$>i$;++i$)num=list[i$],accum$.push(math.cube(num));return accum$}.call(this,[])}.call(this);
-/*
-//@ sourceMappingURL=test/fixtures/expected/sourcemapin
-*/
+//# sourceMappingURL=test/fixtures/expected/sourcemapin

--- a/test/fixtures/expected/sourcemapurl.js
+++ b/test/fixtures/expected/sourcemapurl.js
@@ -1,4 +1,2 @@
 function longFunctionC(n,o){return longNameA+longNameB+n+o}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-/*
-//@ sourceMappingURL=js/sourcemapurl.js.map
-*/
+//# sourceMappingURL=js/sourcemapurl.js.map


### PR DESCRIPTION
The upstream specification has changed since #44 was closed from //@ to //# which avoids IE conditional comment compatibility issues and thus the need to wrap the declaration in a /\* */ comment.

See:
    https://github.com/mishoo/UglifyJS2/pull/213#issuecomment-18215308
    https://bugzilla.mozilla.org/show_bug.cgi?id=870361
