### PR TITLE
Include banner in size report

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -102,7 +102,7 @@ module.exports = function(grunt) {
 
       // ...and report some size information.
       if (options.report) {
-        contrib.minMaxInfo(result.min, result.max, options.report);
+        contrib.minMaxInfo(output, result.max, options.report);
       }
     });
   });


### PR DESCRIPTION
Currently, the file size report shows minified and Gzipped totals which _don't_ include any banners that may have been prepended to the file, giving a false impression of the final file size.

In this pull request, I have updated the call to 'minMaxInfo' to include the full contents of the minified file, not just the code generated by UglifyJS.
