### PR TITLE
customs output sourcemap attributes and sets sourMappingURL on banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+.idea

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v0.2.4:
+  date: 2013-09-02
+  changes:
+    - updated sourcemap format via /83
+v0.2.3:
+  date: 2013-06-10
+  changes:
+    - added footer option
 v0.2.2:
   date: 2013-05-31
   changes:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
  * grunt-contrib-uglify
  * http://gruntjs.com/
  *
- * Copyright (c) 2012 "Cowboy" Ben Alman, contributors
+ * Copyright (c) 2013 "Cowboy" Ben Alman, contributors
  * Licensed under the MIT license.
  */
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ grunt.initConfig({
 
 ## Release History
 
+ * 2013-09-02   v0.2.4   updated sourcemap format via /83
+ * 2013-06-10   v0.2.3   added footer option
  * 2013-05-31   v0.2.2   Reverted /56 due to /58 until [chrome/239660](https://code.google.com/p/chromium/issues/detail?id=239660&q=sourcemappingurl&colspec=ID%20Pri%20M%20Iteration%20ReleaseBlock%20Cr%20Status%20Owner%20Summary%20OS%20Modified) [firefox/870361](https://bugzilla.mozilla.org/show_bug.cgi?id=870361) drop
  * 2013-05-22   v0.2.1   Bumped uglify to ~2.3.5 /55 /40 Changed sourcemappingUrl syntax /56 Disabled sorting of names for consistent mangling /44 Updated docs for sourceMapRoot /47 /25
  * 2013-03-14   v0.2.0   No longer report gzip results by default. Support `report` option.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-uglify",
   "description": "Minify files with UglifyJS.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://github.com/gruntjs/grunt-contrib-uglify",
   "author": {
     "name": "Grunt Team",
@@ -20,7 +20,6 @@
       "url": "https://github.com/gruntjs/grunt-contrib-uglify/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.8.0"
   },
@@ -28,13 +27,13 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "uglify-js": "~2.3.5",
-    "grunt-lib-contrib": "~0.6.0"
+    "uglify-js": "~2.4.0",
+    "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.2.0",
+    "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-internal": "~0.4.2",
     "grunt": "~0.4.0"
   },

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -2,7 +2,7 @@
  * grunt-contrib-uglify
  * https://gruntjs.com/
  *
- * Copyright (c) 2012 "Cowboy" Ben Alman, contributors
+ * Copyright (c) 2013 "Cowboy" Ben Alman, contributors
  * Licensed under the MIT license.
  */
 
@@ -81,7 +81,7 @@ exports.init = function(grunt) {
 
     if (options.sourceMappingURL || options.sourceMap) {
       if (!/\/\/[@#] sourceMappingURL=/.exec(options.banner)) {
-        min += "\n/*\n//@ sourceMappingURL=" + (options.sourceMappingURL || options.sourceMap) + "\n*/";
+        min += "\n//# sourceMappingURL=" + (options.sourceMappingURL || options.sourceMap);
       }
     }
 

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -2,7 +2,7 @@
  * grunt-contrib-uglify
  * http://gruntjs.com/
  *
- * Copyright (c) 2012 "Cowboy" Ben Alman, contributors
+ * Copyright (c) 2013 "Cowboy" Ben Alman, contributors
  * Licensed under the MIT license.
  */
 

--- a/test/fixtures/expected/multiple_sourcemaps1.js
+++ b/test/fixtures/expected/multiple_sourcemaps1.js
@@ -1,4 +1,2 @@
 function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-/*
-//@ sourceMappingURL=test/fixtures/expected/multiple_sourcemaps1.mapurl
-*/
+//# sourceMappingURL=test/fixtures/expected/multiple_sourcemaps1.mapurl

--- a/test/fixtures/expected/multiple_sourcemaps2.js
+++ b/test/fixtures/expected/multiple_sourcemaps2.js
@@ -1,4 +1,2 @@
 function foo(){return 42}function bar(){return 2*foo()}function baz(){return bar()*bar()}
-/*
-//@ sourceMappingURL=test/fixtures/expected/multiple_sourcemaps2.mapurl
-*/
+//# sourceMappingURL=test/fixtures/expected/multiple_sourcemaps2.mapurl

--- a/test/fixtures/expected/sourcemapin.js
+++ b/test/fixtures/expected/sourcemapin.js
@@ -1,4 +1,2 @@
 void function(){var cubes,list,math,number,opposite,race,square;number=42,opposite=!0,opposite&&(number=-42),square=function(x){return x*x},list=[1,2,3,4,5],math={root:Math.sqrt,square:square,cube:function(x){return x*square(x)}},race=function(winner,runners){return runners=2<=arguments.length?[].slice.call(arguments,1):[],print(winner,runners)},"undefined"!=typeof elvis&&null!=elvis&&alert("I knew it!"),cubes=function(accum$){for(var num,i$=0,length$=list.length;length$>i$;++i$)num=list[i$],accum$.push(math.cube(num));return accum$}.call(this,[])}.call(this);
-/*
-//@ sourceMappingURL=test/fixtures/expected/sourcemapin
-*/
+//# sourceMappingURL=test/fixtures/expected/sourcemapin

--- a/test/fixtures/expected/sourcemapurl.js
+++ b/test/fixtures/expected/sourcemapurl.js
@@ -1,4 +1,2 @@
 function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-/*
-//@ sourceMappingURL=js/sourcemapurl.js.map
-*/
+//# sourceMappingURL=js/sourcemapurl.js.map

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -42,7 +42,7 @@ exports.contrib_uglify = {
       'multiple_sourcemaps1.js',
       'multiple_sourcemaps1.map',
       'multiple_sourcemaps2.js',
-      'multiple_sourcemaps2.map',
+      'multiple_sourcemaps2.map'
     ];
 
     test.expect(files.length);


### PR DESCRIPTION
Changes attributes of source map.
Sets `sourceMappingURL` in the banner.

``` sh
> grunt
```

``` js
      sourcemap_banner: {
        files: {
          'tmp/sourcemap_banner.js': ['test/fixtures/src/simple.js']
        },
        options: {
          banner: '/*\n//@ sourceMappingURL=sourcemap_banner\n*/\n',
          sourceMap: 'tmp/sourcemap_banner'
        }
      }

// output min file
/*
//@ sourceMappingURL=sourcemap_banner
*/
function longFunctionC...
```

``` js
      sourcemap_override: {
        files: {
          'tmp/sourcemap_override.js': ['test/fixtures/src/simple.js']
        },
        options: {
          sourceMap: 'tmp/sourcemap_override',
          sourceMapOverride: {
            file: 'simple.min.js',
            sources: ['simple.js']
          }
        }
      },

// output source map
{"version":3,"file":"simple.min.js","sources":["simple.js"],"names":"..."}
```
