### PR TITLE
Happy messages are logged via verbose

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -102,11 +102,11 @@ module.exports = function(grunt) {
       // Write source map
       if (options.sourceMap) {
         grunt.file.write(options.sourceMap, result.sourceMap);
-        grunt.log.writeln('Source Map "' + options.sourceMap + '" created.');
+        grunt.verbose.writeln('Source Map "' + options.sourceMap + '" created.');
       }
 
       // Print a success message.
-      grunt.log.writeln('File "' + f.dest + '" created.');
+      grunt.verbose.writeln('File "' + f.dest + '" created.');
 
       // ...and report some size information.
       if (options.report) {


### PR DESCRIPTION
This is a tiny pull request, but when I'm uglifying 1000+ files individually as just one of many steps in my grunt flow, outputting success messages for each file is kind of, well, verbose.

I changed two instances of non-error messages currently output via `grunt.log` to use `grunt.verbose`.
