### PR TITLE
Fixed syntax error in Advanced source maps example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ grunt.initConfig({
         sourceMap: 'path/to/source-map.js',
         sourceMapRoot: 'http://example.com/path/to/src/', // the location to find your original source
         sourceMapIn: 'example/coffeescript-sourcemap.js', // input sourcemap from a previous compilation
-        }
       },
       files: {
         'dest/output.min.js': ['src/input.js']


### PR DESCRIPTION
By the way, I didn't find this error by hand. I made a tool called [mdlint](https://github.com/ChrisWren/mdlint) that validates JavaScript code blocks in markdown files. Check it out if you want to lint READMEs, docs, or blog posts!
