### PR TITLE
Added one option for silent operation. This will suppress the 'success' ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ _(Default processing options are explained in the [grunt.template.process][] doc
 
 [grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#wiki-grunt-template-process
 
+#### silent
+Type: `Boolean`
+Default: false
+
+When true this will supress the 'File "{file name}" created.' and 'Source Map "{file name}" created.' messages. All warnings and errors wil still come through.
 
 ### Usage examples
 

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
       },
       mangle: {},
       beautify: false,
-      report: false
+      report: false,
+      silent: false
     });
 
     // Process banner.
@@ -102,11 +103,15 @@ module.exports = function(grunt) {
       // Write source map
       if (options.sourceMap) {
         grunt.file.write(options.sourceMap, result.sourceMap);
-        grunt.log.writeln('Source Map "' + options.sourceMap + '" created.');
+        if (!options.silent) {
+          grunt.log.writeln('Source Map "' + options.sourceMap + '" created.');
+        }
       }
 
       // Print a success message.
-      grunt.log.writeln('File "' + f.dest + '" created.');
+      if (!options.silent) {
+        grunt.log.writeln('File "' + f.dest + '" created.');
+      }
 
       // ...and report some size information.
       if (options.report) {


### PR DESCRIPTION
...messages. It is defaulted to false, so the operation is as it is today. Large builds did seem to realize an improvement in build times with this set to true.
