### PR TITLE
support UglifyJS screw_ie8 option via screwIe8 property

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Default: `{}`
 
 Turn on or off source compression with default options. If an `Object` is specified, it is passed as options to `UglifyJS.Compressor()`.
 
+#### screwIe8
+Type: `Boolean`
+Default: `false`
+
+By default UglifyJS tries to be IE-proof, passing screw_ie8 makes it not care about IE<9 quirks like leaking named function expressions names to the outer scope. If a project doesn't support IE8 and older, passing this flag can reduce the output file size.
+
 #### beautify
 Type: `Boolean` `Object`
 Default: `false`

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -52,8 +52,14 @@ exports.init = function(grunt) {
     topLevel.figure_out_scope();
 
     if (options.compress !== false) {
+      if (options.compress === true) {
+          options.compress = {};
+      }
       if (options.compress.warnings !== true) {
         options.compress.warnings = false;
+      }
+      if (options.screwIe8) {
+        options.compress.screw_ie8 = options.screwIe8;
       }
       var compressor = UglifyJS.Compressor(options.compress);
       topLevel = topLevel.transform(compressor);
@@ -68,6 +74,13 @@ exports.init = function(grunt) {
       //   2) it increases gzipped file size, see https://github.com/mishoo/UglifyJS2#mangler-options
       // // compute_char_frequency optimizes names for compression
       // topLevel.compute_char_frequency(options.mangle);
+
+      if (options.mangle === true) {
+          options.mangle = {};
+      }
+      if (options.screwIe8) {
+        options.mangle.screw_ie8 = options.screwIe8;
+      }
 
       // Requires previous call to figure_out_scope
       // and should always be called after compressor transform


### PR DESCRIPTION
By default UglifyJS tries to be IE-proof, passing screw_ie8 makes it not care about IE<9 quirks like leaking named function expressions names to the outer scope. If a project doesn't support IE8, passing this flag can reduce the output file size.

This pull request adds a `screwIe8` option to the `uglify` grunt task which is then passed to the UglifyJS mangler & compressor as `screw_ie8`.
