### PR TITLE
Change the sourceMappingURL pragma to use the new //# syntax, update packages

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "uglify-js": "~2.3.5",
-    "grunt-lib-contrib": "~0.6.0"
+    "uglify-js": "~2.4.0",
+    "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.2.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~0.6.3",
+    "grunt-contrib-nodeunit": "~0.2.0",
+    "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-internal": "~0.4.2",
     "grunt": "~0.4.0"
   },

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -80,7 +80,7 @@ exports.init = function(grunt) {
     var min = output.get();
 
     if (options.sourceMappingURL || options.sourceMap) {
-      min += "\n/*\n//@ sourceMappingURL=" + (options.sourceMappingURL || options.sourceMap) + "\n*/";
+      min += "\n//# sourceMappingURL=" + (options.sourceMappingURL || options.sourceMap);
     }
 
     var result = {

--- a/test/fixtures/expected/multiple_sourcemaps1.js
+++ b/test/fixtures/expected/multiple_sourcemaps1.js
@@ -1,4 +1,2 @@
 function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-/*
-//@ sourceMappingURL=test/fixtures/expected/multiple_sourcemaps1.mapurl
-*/
+//# sourceMappingURL=test/fixtures/expected/multiple_sourcemaps1.mapurl

--- a/test/fixtures/expected/multiple_sourcemaps2.js
+++ b/test/fixtures/expected/multiple_sourcemaps2.js
@@ -1,4 +1,2 @@
 function foo(){return 42}function bar(){return 2*foo()}function baz(){return bar()*bar()}
-/*
-//@ sourceMappingURL=test/fixtures/expected/multiple_sourcemaps2.mapurl
-*/
+//# sourceMappingURL=test/fixtures/expected/multiple_sourcemaps2.mapurl

--- a/test/fixtures/expected/sourcemapin.js
+++ b/test/fixtures/expected/sourcemapin.js
@@ -1,4 +1,2 @@
 void function(){var cubes,list,math,number,opposite,race,square;number=42,opposite=!0,opposite&&(number=-42),square=function(x){return x*x},list=[1,2,3,4,5],math={root:Math.sqrt,square:square,cube:function(x){return x*square(x)}},race=function(winner,runners){return runners=2<=arguments.length?[].slice.call(arguments,1):[],print(winner,runners)},"undefined"!=typeof elvis&&null!=elvis&&alert("I knew it!"),cubes=function(accum$){for(var num,i$=0,length$=list.length;length$>i$;++i$)num=list[i$],accum$.push(math.cube(num));return accum$}.call(this,[])}.call(this);
-/*
-//@ sourceMappingURL=test/fixtures/expected/sourcemapin
-*/
+//# sourceMappingURL=test/fixtures/expected/sourcemapin

--- a/test/fixtures/expected/sourcemapurl.js
+++ b/test/fixtures/expected/sourcemapurl.js
@@ -1,4 +1,2 @@
 function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-/*
-//@ sourceMappingURL=js/sourcemapurl.js.map
-*/
+//# sourceMappingURL=js/sourcemapurl.js.map


### PR DESCRIPTION
All browsers that implemented support for source maps except for Chrome (i.e. Firefox & Safari) did it in the same versions that got the updated `//# sourceMappingURL` pragma syntax (Firefox in version 24, Safari in 6.1/7). Chrome has updated the pragma in version 29 which has already been released so it's time to switch.

This pull request also updates node dependencies of the project.
