### PR TITLE
Improving the error message when a file can't be minified

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -86,7 +86,10 @@ module.exports = function(grunt) {
       } catch (e) {
         var err = new Error('Uglification failed.');
         if (e.message) {
-          err.message += ', ' + e.message + '.';
+          err.message += '\n' + e.message + '. \n';
+          if (e.line) {
+            err.message += 'Line ' + e.line + ' in ' + src + '\n';
+          }
         }
         err.origError = e;
         grunt.log.warn('Uglifying source "' + src + '" failed.');


### PR DESCRIPTION
Before:
Warning: Uglification failed. Use --force to continue.

Now:

Warning: Uglification failed.
Unexpected token: keyword (function). 
Line 69 in public/cdn/js/app.js
 Use --force to continue.
