### PR TITLE
Added support for sourcesContent in passed in source map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-uglify",
   "description": "Minify files with UglifyJS.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "homepage": "https://github.com/gruntjs/grunt-contrib-uglify",
   "author": {
     "name": "Grunt Team",

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -136,6 +136,13 @@ exports.init = function(grunt) {
         root: options.sourceMapRoot,
         orig: sourceMapIn
       });
+
+      if (!grunt.util._.isUndefined(sourceMapIn) && grunt.util._.isArray(sourceMapIn.sourcesContent)){
+        var generator = outputOptions.source_map.get();
+        sourceMapIn.sources.forEach(function(file, i) {
+          generator.setSourceContent(file, sourceMapIn.sourcesContent[i]);
+        });
+      }
     }
 
     return outputOptions;


### PR DESCRIPTION
When the input source map contains sourcesContent, the output from grunt-contrib-uglify will now also contain it.
