### PR TITLE
Fix typo in error message for sourceMappingURL function failure

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
         try {
           options.sourceMappingURL = mappingURLGenerator(f.dest);
         } catch (e) {
-          var err = new Error('SourceMapName failed.');
+          var err = new Error('SourceMappingURL failed.');
           err.origError = e;
           grunt.fail.warn(err);
         }


### PR DESCRIPTION
Just a small typo for the error message when the sourceMappingURL function fails.
