### PR TITLE
Add support for uglify ascii_only option

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -138,6 +138,9 @@ exports.init = function(grunt) {
       }
     }
 
+    if (options.ascii_only) {
+      outputOptions.ascii_only = true;
+    }
 
     if (options.sourceMap) {
       var sourceMapIn;

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
       },
       mangle: {},
       beautify: false,
-      report: false
+      report: false,
+      ascii_only: false
     });
 
     // Process banner.


### PR DESCRIPTION
It's available in UglifyJS, and it's useful for [dodging unicode issues](https://github.com/mishoo/UglifyJS2/issues/54).
