### PR TITLE
Use chalk module to colorize terminal output and unify message format

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "uglify-js": "~2.4.0",
-    "grunt-lib-contrib": "~0.6.1"
+    "grunt-lib-contrib": "~0.6.1",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.3",

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -14,6 +14,8 @@ module.exports = function(grunt) {
   var contrib = require('grunt-lib-contrib').init(grunt);
   var uglify = require('./lib/uglify').init(grunt);
 
+  var chalk = require('chalk');
+
   grunt.registerMultiTask('uglify', 'Minify files with UglifyJS.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
@@ -133,11 +135,11 @@ module.exports = function(grunt) {
       // Write source map
       if (options.sourceMap) {
         grunt.file.write(options.sourceMap, result.sourceMap);
-        grunt.log.writeln('Source Map "' + options.sourceMap + '" created.');
+        grunt.log.writeln('File ' + chalk.cyan(options.sourceMap) + ' created (source map).');
       }
 
       // Print a success message.
-      grunt.log.writeln('File "' + f.dest + '" created.');
+      grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
 
       // ...and report some size information.
       if (options.report) {


### PR DESCRIPTION
- Add [chalk](https://github.com/sindresorhus/chalk) as a dependency.
- Output the name of the files that have been created colorized in cyan and without quotes, which is arguably more readable, unifying with other `grunt-contrib-*` tasks.
- Minor changes in message strings.
