### PR TITLE
Fixes source file reference in source map

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -43,8 +43,9 @@ exports.init = function(grunt) {
       var fileDir = path.dirname(file);
       var sourceMapDir = path.dirname(options.generatedSourceMapName);
       var relativePath = path.relative(sourceMapDir, fileDir);
+      var pathPrefix = relativePath ? (relativePath+path.sep) : "";
 
-      file = relativePath + path.sep + basename;
+      file = pathPrefix + basename;
 
       sourcesContent[file] = code;
       topLevel = UglifyJS.parse(code, {


### PR DESCRIPTION
Fixes a minor bug regarding the location of relative source files. It would previously append a path separator even for files in the same directory, which, of course, is then interpreted as being in the root directory.

To give an example, if your source files and source map were in the same directory, the reference would always be `[ "/script-one.js", "/script-two.js" ]`. But if your website is viewed from, say, `http://some-domain.com/myHomepage/` (and the scripts are relative to that path), this reference would break.

The fix is simple. Only append the path separator when a relative directory exists. Otherwise, don't.
