### PR TITLE
Ignores sourceMapIncludeSources option when sourceMap isn't true

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -95,7 +95,7 @@ exports.init = function(grunt) {
       topLevel.mangle_names(options.mangle);
     }
 
-    if (options.sourceMapIncludeSources) {
+    if (options.sourceMap && options.sourceMapIncludeSources) {
       for (var file in sourcesContent) {
         if (sourcesContent.hasOwnProperty(file)) {
           outputOptions.source_map.get().setSourceContent(file, sourcesContent[file]);


### PR DESCRIPTION
Fixes #145.

`sourceMapIncludeSources` is an option that only does anything when `sourceMap` is true. Right now, though, uglify errors out when `sourceMapIncludeSources` is true, but `sourceMap` is false. This modifies the behavior to simply ignore the option when `sourceMap` is false.
