### PR TITLE
Amended replacement of path slashes

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -45,10 +45,10 @@ exports.init = function(grunt) {
       var relativePath = path.relative(sourceMapDir, fileDir);
       var pathPrefix = relativePath ? (relativePath+path.sep) : '';
 
-      file = pathPrefix + basename;
-
       // Convert paths to use forward slashes for sourcemap use in the browser
-      sourcesContent[file.replace(/\\/g, '/')] = code;
+      file = (pathPrefix + basename).replace(/\\/g, '/');
+
+      sourcesContent[file] = code;
       topLevel = UglifyJS.parse(code, {
         filename: file,
         toplevel: topLevel


### PR DESCRIPTION
Slashes in the paths are now replaced before being sent to the parser.
This is for generating source maps on Windows with forward slashes in
the paths. Fixes #181 

// cc @UltCombo
