### PR TITLE
Simplify default source map naming function

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -14,12 +14,7 @@ var maxmin = require('maxmin');
 
 // Generate the default source map name
 function getSourceMapLocation( dest ) {
-
-  var destDirname = path.dirname(dest);
-  var destBasename = path.basename(dest);
-
-  return destDirname + path.sep + destBasename + ".map";
-
+  return dest + ".map";
 }
 
 // Return the relative path from file1 => file2


### PR DESCRIPTION
Right now, the current [default source map naming function](https://github.com/gruntjs/grunt-contrib-uglify/blob/master/tasks/uglify.js#L18-L21) splits the directory and filename just to join them again.

I guess it made sense before [PR184](https://github.com/gruntjs/grunt-contrib-uglify/pull/184/files) but not so much now.
