### PR TITLE
Banner: delegate banner handling to Uglify's preamble, fixes #191

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,12 +43,12 @@ module.exports = function(grunt) {
           'tmp/compress_mangle.js': ['test/fixtures/src/simple.js']
         }
       },
-      compress_mangle_banner: {
+      compress_mangle_preamble: {
         files: {
           'tmp/compress_mangle_banner.js': ['test/fixtures/src/simple.js']
         },
-        options : {
-          banner : '// banner without sourcemap\n'
+        options: {
+          preamble: '// banner without sourcemap\n'
         }
       },
       no_src: {
@@ -182,7 +182,7 @@ module.exports = function(grunt) {
         },
         options: {
           mangle: false,
-          banner: '// Hello World\n',
+          preamble: '// Hello World\n',
           sourceMap: true,
           sourceMapIn: function() {
             return 'test/fixtures/src/simple2.map';
@@ -240,7 +240,7 @@ module.exports = function(grunt) {
     'clean',
     'uglify:compress',
     'uglify:compress_mangle',
-    'uglify:compress_mangle_banner',
+    'uglify:compress_mangle_preamble',
     'uglify:no_src',
     'uglify:compress_mangle_except',
     'uglify:compress_mangle_beautify',

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Turn on preservation of comments.
 - `'some'` will preserve all comments that start with a bang (`!`) or include a closure compiler style directive (`@preserve` `@license` `@cc_on`)
 - `Function` specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either `true` or `false`
 
-#### banner
+#### preamble
 Type: `String`  
 Default: empty string
 
@@ -414,4 +414,4 @@ grunt.initConfig({
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com)
 
-*This file was generated on Tue Apr 08 2014 18:01:12.*
+*This file was generated on Thu May 01 2014 20:02:26.*

--- a/docs/uglify-options.md
+++ b/docs/uglify-options.md
@@ -89,7 +89,7 @@ Turn on preservation of comments.
 - `'some'` will preserve all comments that start with a bang (`!`) or include a closure compiler style directive (`@preserve` `@license` `@cc_on`)
 - `Function` specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either `true` or `false`
 
-## banner
+## preamble
 Type: `String`  
 Default: empty string
 

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -147,9 +147,7 @@ exports.init = function(grunt) {
       }
     }
 
-    if (options.banner && options.sourceMap) {
-      outputOptions.preamble = options.banner;
-    }
+    outputOptions.preamble = options.preamble;
 
     if (options.beautify) {
       if (_.isObject(options.beautify)) {

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -47,8 +47,7 @@ module.exports = function(grunt) {
       report: 'min'
     });
 
-    // Process banner.
-    var banner = normalizeLf(options.banner);
+    // Process footer. Banner processing is done by Uglify.
     var footer = normalizeLf(options.footer);
     var mapNameGenerator, mapInNameGenerator;
 
@@ -138,11 +137,6 @@ module.exports = function(grunt) {
 
       // Concat minified source + footer
       var output = result.min + footer;
-
-      // Only prepend banner if uglify hasn't taken care of it as part of the preamble
-      if (!options.sourceMap) {
-        output = banner + output;
-      }
 
       // Write the destination file.
       grunt.file.write(f.dest, output);

--- a/test/fixtures/expected/compress_mangle_banner.js
+++ b/test/fixtures/expected/compress_mangle_banner.js
@@ -1,2 +1,3 @@
 // banner without sourcemap
+
 function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);


### PR DESCRIPTION
Lets Uglify do banner handling and consequent normalization independent of the `sourceMap` config. This way, any future issue with the banner should be reported to [Uglify](https://github.com/mishoo/UglifyJS2/issues).

I'm not sure how to write a proper test for this, I believe the ideal unit test would be uglifying the same file with `sourceMap: true` and without, then compare with each other or against the same expected file. Problem is, as each uglify target generates a temp file and checks it against an expected file, I'd need to make 2 copies of the same file with different filenames which is not DRY and does not make the intention of having 2 different settings output the same code output clear -- not very useful seeing as there are already banner tests with and without source maps.

I'd like some tips/suggestions for the tests if these are necessary. 

cc @jmeas 
