### PR TITLE
Truncate destination file

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -65,6 +65,7 @@ module.exports = function(grunt) {
       });
 
       if (src.length === 0) {
+        grunt.file.write(f.dest, '');
         grunt.log.warn('Destination ' + chalk.cyan(f.dest) + ' not written because src files were empty.');
         return;
       }


### PR DESCRIPTION
Currently if you had pre-existing source files that has previously compiled into the destination file, then subsequently remove the source files from the grunt file, it won't truncate the destination file as it warns that

```
Destination {destination} not written because src files were empty.
```

I think it should truncate the file or remove the file, a similar approach should be taken to the source map but it makes no sense to keep the source map around but truncated.
