### PR TITLE
Properly encode URI paths, closes #222

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "chalk": "^0.4.0",
     "lodash": "^2.4.1",
     "maxmin": "^0.2.0",
-    "uglify-js": "^2.4.0"
+    "uglify-js": "^2.4.0",
+    "uri-path": "0.0.2"
   },
   "devDependencies": {
     "grunt": "^0.4.2",

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -13,6 +13,7 @@ var path = require('path');
 var fs = require('fs');
 var UglifyJS = require('uglify-js');
 var _ = require('lodash');
+var uriPath = require('uri-path');
 
 exports.init = function(grunt) {
   var exports = {};
@@ -46,7 +47,7 @@ exports.init = function(grunt) {
       var pathPrefix = relativePath ? (relativePath+path.sep) : '';
 
       // Convert paths to use forward slashes for sourcemap use in the browser
-      file = (pathPrefix + basename).replace(/\\/g, '/');
+      file = uriPath(pathPrefix + basename);
 
       sourcesContent[file] = code;
       topLevel = UglifyJS.parse(code, {
@@ -115,7 +116,7 @@ exports.init = function(grunt) {
     // Add the source map reference to the end of the file
     if (options.sourceMap) {
       // Set all paths to forward slashes for use in the browser
-      min += "\n//# sourceMappingURL="+options.destToSourceMap.replace(/\\/g, '/');
+      min += "\n//# sourceMappingURL=" + uriPath(options.destToSourceMap);
     }
 
     var result = {


### PR DESCRIPTION
#222

Properly encode the source mapping URL and source URLs array in accordance to RFC3986 as required by the [Source Map spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.75yo6yoyk7x5):

> Note: &lt;url> is a URL as defined in RFC3986; in particular, characters outside the set permitted to appear in URIs must be percent-encoded.

//cc @jmeas
