### PR TITLE
npm v2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "^0.5.1",
-    "lodash": "^2.4.1",
-    "maxmin": "^0.2.0",
-    "uglify-js": "^2.4.0",
+    "chalk": "~0.5.1",
+    "lodash": "~2.4.1",
+    "maxmin": "~0.2.0",
+    "uglify-js": "~2.4.0",
     "uri-path": "0.0.2"
   },
   "devDependencies": {
-    "grunt": "^0.4.2",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-internal": "^0.4.2",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.4.0"
+    "grunt": "~0.4.2",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-internal": "~0.4.2",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "~0.4.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
Note: `~` might not be the correct matcher for all the dependencies
