### PR TITLE
Fix the `report` option

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
         grunt.verbose.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
       }
 
-      grunt.verbose.writeln('File ' + chalk.cyan(f.dest) + ' created: ' +
+      grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created: ' +
                         maxmin(result.max, output, options.report === 'gzip'));
     });
   });


### PR DESCRIPTION
Fix the `report` option by using  `grunt.log` instead of  `grunt.verbose`

I upgraded from `0.2.x` and there `uglify` had one `grunt.log` print:

```
File dist/1/xhook.min.js created: 13.23 kB → 5.82 kB → 2.52 kB (gzip)
```

It seems to only `grunt.verbose` print now. Maybe this was on purpose?
