### PR TITLE
Optionally set report verbosity level using report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ Default: `false`
 Parse a single expression, rather than a program (for parsing JSON)
 
 #### report
-Choices: `'min'`, `'gzip'`  
+Choices: `false, 'none', 'min'`, `'gzip'`
 Default: `'min'`
 
 Either report only minification result or report minification and gzip results.
 This is useful to see exactly how well clean-css is performing but using `'gzip'` will make the task take 5-10x longer to complete. [Example output](https://github.com/sindresorhus/maxmin#readme).
+If false or 'none' is used the report will be generated on the verbose output.
 
 #### sourceMap
 Type: `Boolean`  

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -25,10 +25,9 @@ function relativePath(file1, file2) {
 
 }
 
-function report_facility( grunt, options ){
+function reportFacility( grunt, options ){
   var reporter;
   switch( options.report ){
-    case false:
     case 'none':
       reporter = grunt.verbose;
       break;
@@ -65,7 +64,7 @@ module.exports = function(grunt) {
       ASCIIOnly: false,
       screwIE8: false
     });
-    var reportLog  = report_facility( grunt, options );
+    var log = reportFacility( grunt, options );
 
     // Process banner.
     var banner = normalizeLf(options.banner);
@@ -184,12 +183,12 @@ module.exports = function(grunt) {
       // Write source map
       if (options.sourceMap) {
         grunt.file.write(options.generatedSourceMapName, result.sourceMap);
-        reportLog.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
+        log.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
         createdMaps++;
       }
 
       var outputSize = maxmin(result.max, output, options.report === 'gzip');
-      reportLog.writeln('File ' + chalk.cyan(f.dest) + ' created: ' + outputSize);
+      log.writeln('File ' + chalk.cyan(f.dest) + ' created: ' + outputSize);
 
       createdFiles++;
     });

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -25,6 +25,21 @@ function relativePath(file1, file2) {
 
 }
 
+function report_facility( grunt, options ){
+  var reporter;
+  switch( options.report ){
+    case false:
+    case 'none':
+      reporter = grunt.verbose;
+      break;
+    default:
+    case 'min':
+    case 'gzip':
+      reporter = grunt.log;
+  }
+  return reporter;
+}
+
 // Converts \r\n to \n
 function normalizeLf( string ) {
   return string.replace(/\r\n/g, '\n');
@@ -50,6 +65,7 @@ module.exports = function(grunt) {
       ASCIIOnly: false,
       screwIE8: false
     });
+    var reportLog  = report_facility( grunt, options );
 
     // Process banner.
     var banner = normalizeLf(options.banner);
@@ -168,12 +184,13 @@ module.exports = function(grunt) {
       // Write source map
       if (options.sourceMap) {
         grunt.file.write(options.generatedSourceMapName, result.sourceMap);
-        grunt.verbose.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
+        reportLog.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
         createdMaps++;
       }
 
-      grunt.verbose.writeln('File ' + chalk.cyan(f.dest) + ' created: ' +
-        maxmin(result.max, output, options.report === 'gzip'));
+      var outputSize = maxmin(result.max, output, options.report === 'gzip');
+      reportLog.writeln('File ' + chalk.cyan(f.dest) + ' created: ' + outputSize);
+
       createdFiles++;
     });
 


### PR DESCRIPTION
This pull request restores the documented behavior of generating the min/gzip reports at the standard log level while introducing the option to log the output to the verbose log using the values 'none' or false.  I believe this is a happy middle ground between between 4944e2c547858656af36098202022e22cb1fdbe2 and #254.

Resolves:
#254
#257 
#276 

Related To:
#259
#137 - changes from 4944e2c547858656af36098202022e22cb1fdbe2 look identical 
#229 - (Pull request)
