### PR TITLE
Adding quote_style option. Fixes #293.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -326,6 +326,30 @@ module.exports = function(grunt) {
           mangleProperties: true,
           nameCache: 'tmp/uglify_name_cache.json'
         }
+      },
+      quotes_single: {
+        files: {
+          'tmp/quotes_single.js': ['test/fixtures/src/quotes.js']
+        },
+        options: {
+          quoteStyle: 1
+        }
+      },
+      quotes_double: {
+        files: {
+          'tmp/quotes_double.js': ['test/fixtures/src/quotes.js']
+        },
+        options: {
+          quoteStyle: 2
+        }
+      },
+      quotes_original: {
+        files: {
+          'tmp/quotes_original.js': ['test/fixtures/src/quotes.js']
+        },
+        options: {
+          quoteStyle: 3
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,18 @@ Type: `Boolean`
 Default: false
 
 Pass this flag if you don't care about full compliance with Internet Explorer 6-8 quirks.
-
+  
+#### quoteStyle
+Type: `Integer`
+Default: `0`
+  
+Preserve or enforce quotation mark style.
+- `0` will use single or double quotes such as to minimize the number of bytes (prefers double quotes when both will do)
+- `1` will always use single quotes
+- `2` will always use double quotes
+- `3` will preserve original quotation marks
+  
+  
 ### Usage examples
 
 #### Basic compression

--- a/docs/uglify-options.md
+++ b/docs/uglify-options.md
@@ -167,3 +167,14 @@ A string that is a path to a JSON cache file that uglify will create and use to 
 multiple runs of uglify. Note: this generated file uses the same JSON format as the `exceptionsFiles` files.
 
 
+
+## quoteStyle
+Type: `Integer`
+Default: `0`
+
+Preserve or enforce quotation mark style.
+
+- `0` will use single or double quotes such as to minimize the number of bytes (prefers double quotes when both will do)
+- `1` will always use single quotes
+- `2` will always use double quotes
+- `3` will preserve original quotation marks

--- a/docs/uglify-overview.md
+++ b/docs/uglify-overview.md
@@ -19,3 +19,4 @@ Version `3.x` introduced changes to configuring source maps. Accordingly, if you
 `sourceMapName` - Accepts a string or function to change the location or name of your map
 `sourceMapIncludeSources` - Embed the content of your source files directly into the map
 `expression` - Accepts a `Boolean` value. Parse a single expression (JSON or single functions)
+`quoteStyle` - Accepts integers `0` (default), `1`, `2`, `3`. Enforce or preserve quotation mark style.

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -248,16 +248,20 @@ exports.init = function(grunt) {
       }
     }
 
-    if (options.indentLevel !== undefined) {
+    if (!_.isUndefined(options.indentLevel)) {
       outputOptions.indent_level = options.indentLevel;
     }
 
-    if (options.maxLineLen !== undefined) {
+    if (!_.isUndefined(options.maxLineLen)) {
       outputOptions.max_line_len = options.maxLineLen;
     }
 
-    if (options.ASCIIOnly !== undefined) {
+    if (!_.isUndefined(options.ASCIIOnly)) {
       outputOptions.ascii_only = options.ASCIIOnly;
+    }
+
+    if (!_.isUndefined(options.quoteStyle)) {
+      outputOptions.quote_style = options.quoteStyle;
     }
 
     return outputOptions;

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -48,7 +48,8 @@ module.exports = function(grunt) {
       expression: false,
       maxLineLen: 32000,
       ASCIIOnly: false,
-      screwIE8: false
+      screwIE8: false,
+      quoteStyle: 0
     });
 
     // Process banner.

--- a/test/fixtures/expected/quotes_double.js
+++ b/test/fixtures/expected/quotes_double.js
@@ -1,0 +1,1 @@
+function llama(){var a="This is a single quote string",b="This is a double quote string",c={"this":"is part of an Object",and:"so is this",but:"this one has \"mixed\" quotes: '"};return[a,b,c]}

--- a/test/fixtures/expected/quotes_original.js
+++ b/test/fixtures/expected/quotes_original.js
@@ -1,0 +1,1 @@
+function llama(){var a='This is a single quote string',b="This is a double quote string",c={"this":"is part of an Object",and:'so is this',but:'this one has "mixed" quotes: \''};return[a,b,c]}

--- a/test/fixtures/expected/quotes_single.js
+++ b/test/fixtures/expected/quotes_single.js
@@ -1,0 +1,1 @@
+function llama(){var a='This is a single quote string',b='This is a double quote string',c={'this':'is part of an Object',and:'so is this',but:'this one has "mixed" quotes: \''};return[a,b,c]}

--- a/test/fixtures/src/quotes.js
+++ b/test/fixtures/src/quotes.js
@@ -1,0 +1,11 @@
+function llama() {
+  var a = 'This is a single quote string';
+  var b = "This is a double quote string";
+  var c = {
+    "this": "is part of an Object",
+    'and': 'so is this',
+    'but': 'this one has "mixed" quotes: \''
+  };
+
+  return [a, b, c];
+}

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -56,7 +56,10 @@ exports.contrib_uglify = {
       'mangleprops_withExceptAndExceptionsFiles.js',
       'mangleprops_withNameCacheFile1.js',
       'mangleprops_withNameCacheFile2.js',
-      'uglify_name_cache.json'
+      'uglify_name_cache.json',
+      'quotes_single.js',
+      'quotes_double.js',
+      'quotes_original.js'
     ];
 
     test.expect(files.length);


### PR DESCRIPTION
See #293. Also includes new test fixture. Two notes:

1. I didn't write a test for the default case (`-q 0`). Please let me know if I should do so.
1. I used the same semi-descriptive flags that `uglifyjs` does — i.e., `0`, `1`, `2`, `3`. Please let me know if I should change it to something more intuitive like `single`, `double`, `original`, `default`.