### PR TITLE
Fix sourceMapRoot being ignored

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -127,13 +127,9 @@ module.exports = function(grunt) {
       // Calculate the path from the dest file to the sourcemap for the
       // sourceMappingURL reference
       if (options.sourceMap) {
-          var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
-          var sourceMapBasename = path.basename(options.generatedSourceMapName);
-        if(options.sourceMapUrl === undefined) {
-          options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
-        } else {
-          options.destToSourceMap = options.sourceMapUrl;
-        }
+        var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
+        var sourceMapBasename = path.basename(options.generatedSourceMapName);
+        options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
       }
 
       if (options.screwIE8) {

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -127,7 +127,7 @@ module.exports = function(grunt) {
       // Calculate the path from the dest file to the sourcemap for the
       // sourceMappingURL reference
       if (options.sourceMap) {
-        var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
+        var destToSourceMapPath = options.sourceMapRoot === undefined ? relativePath(f.dest, options.generatedSourceMapName) : options.sourceMapRoot;
         var sourceMapBasename = path.basename(options.generatedSourceMapName);
         options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
       }

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -127,9 +127,13 @@ module.exports = function(grunt) {
       // Calculate the path from the dest file to the sourcemap for the
       // sourceMappingURL reference
       if (options.sourceMap) {
-        var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
-        var sourceMapBasename = path.basename(options.generatedSourceMapName);
-        options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
+          var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
+          var sourceMapBasename = path.basename(options.generatedSourceMapName);
+        if(options.sourceMapUrl === undefined) {
+          options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
+        } else {
+          options.destToSourceMap = options.sourceMapUrl;
+        }
       }
 
       if (options.screwIE8) {


### PR DESCRIPTION
When setting sourceMapRoot in Grunt it is being ignored by uglify-js. This PR fixes that by using the sourceMapRoot when calculating options.destToSourceMap by using the sourceMapRoot in place of the relative path when it is set.