### PR TITLE
update uglify-js dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chalk": "^1.0.0",
     "lodash": "^3.2.0",
     "maxmin": "^1.0.0",
-    "uglify-js": "^2.4.19",
+    "uglify-js": "^2.4.20",
     "uri-path": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a bug in the new property mangling feature of uglify v2.4.19. Specifically this code:

```
PIECES: for (var i = 0; i < 10; i++) {
    break PIECES;
}
```

would brokenly mangle to:

```
PIECES: for (var i = 0; i < 10; i++) {
    break a;
}
```

if the 'mangle properties' feature was turned on. This has been fixed in v2.4.20 of ugllify.

This PR is to bump the package.json uglify version dependency.
