### PR TITLE
Add 'sourceMapUrl' option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,6 +184,14 @@ module.exports = function(grunt) {
           sourceMapRoot: 'https://github.com/RReverser/grunt-contrib-uglify/tree/master/tmp'
         }
       },
+      sourcemap_customUrl: {
+        src: 'test/fixtures/src/simple.js',
+        dest: 'tmp/sourcemap_customUrl.js',
+        options: {
+          sourceMap: true,
+          sourceMapUrl: 'http://www.test.com/test/sourcemap_customUrl.js.map'
+        }
+      },
       sourcemap_functionName: {
         src: 'test/fixtures/src/simple.js',
         dest: 'tmp/sourcemap_functionName.js',

--- a/docs/uglify-options.md
+++ b/docs/uglify-options.md
@@ -71,6 +71,12 @@ With this option you can customize root URL that browser will use when looking f
 
 If the sources are not absolute URLs after prepending of the `sourceMapRoot`, the sources are resolved relative to the source map.
 
+## sourceMapUrl
+Type: `String`  
+Default: `undefined`
+
+Override the calculated value for `sourceMappingURL` in the source map. This is useful if the source map location is not relative to the base path of the minified file, i.e. when using a CDN
+
 #### enclose
 Type: `Object`  
 Default: `undefined`

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -177,7 +177,9 @@ exports.init = function(grunt) {
     // Add the source map reference to the end of the file
     if (options.sourceMap) {
       // Set all paths to forward slashes for use in the browser
-      min += '\n//# sourceMappingURL=' + uriPath(options.destToSourceMap);
+      var sourceMappingURL;
+      sourceMappingURL = options.destToSourceMap.match(/^http[s]?\:\/\//) === null ?  uriPath(options.destToSourceMap) : options.destToSourceMap;
+      min += '\n//# sourceMappingURL=' + sourceMappingURL;
     }
 
     var result = {

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -122,10 +122,16 @@ module.exports = function(grunt) {
 
       // Calculate the path from the dest file to the sourcemap for the
       // sourceMappingURL reference
-      if (options.sourceMap) {
-        var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
-        var sourceMapBasename = path.basename(options.generatedSourceMapName);
-        options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
+      // If sourceMapUrl is defined, use this instead
+      if(options.sourceMap) {
+        var destToSourceMapPath, sourceMapBasename;
+        if (!options.sourceMapUrl) {
+          destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
+          sourceMapBasename = path.basename(options.generatedSourceMapName);
+          options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
+        } else {
+          options.destToSourceMap = options.sourceMapUrl;
+        }
       }
 
       if (options.screwIE8) {

--- a/test/fixtures/expected/sourcemap_customUrl.js
+++ b/test/fixtures/expected/sourcemap_customUrl.js
@@ -1,0 +1,2 @@
+function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
+//# sourceMappingURL=http://www.test.com/test/sourcemap_customUrl.js.map

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -32,6 +32,7 @@ exports.contrib_uglify = {
       'sourcemap_customName.js',
       'sourcemap_customRoot.js',
       'sourcemap_customRoot.js.map',
+      'sourcemap_customUrl.js',
       'sourcemap_functionName.js',
       'sourcemap_functionName.js.fn.map',
       path.join('deep', 'directory', 'location', 'source_map.js.map'),


### PR DESCRIPTION
Added an option to override the calculated sourceMappingUrl value in the
minified output.

For my personal use case, I am currently working on a microservice that is loaded into a branding service created by someone else. Due to the way routing is being handled in the branding service, relative URL's cannot be used for accessing the source maps.

This would also solve the issue of hosting the minified javascript and source maps on a CDN, as outlined in #202 