### PR TITLE
Adding a `sourceMappingURLBase` option to set a base URL to the map pointer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -250,6 +250,15 @@ module.exports = function(grunt) {
           sourceMapIncludeSources: true
         }
       },
+      sourcemap_sourceMappingURL: {
+        files: {
+          'tmp/sourcemap_sourceMappingURL.js': ['test/fixtures/src/simple.js']
+        },
+        options: {
+          sourceMap: true,
+          sourceMappingURLBase: 'http://localhost:8080/'
+        }
+      },
       expression_json: {
           files: {
             'tmp/expression.json': ['test/fixtures/src/simple.json']

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -250,9 +250,9 @@ module.exports = function(grunt) {
           sourceMapIncludeSources: true
         }
       },
-      sourcemap_sourceMappingURL: {
+      sourcemap_sourceMappingURLBase: {
         files: {
-          'tmp/sourcemap_sourceMappingURL.js': ['test/fixtures/src/simple.js']
+          'tmp/sourcemap_sourceMappingURLBase.js': ['test/fixtures/src/simple.js']
         },
         options: {
           sourceMap: true,

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ Version `3.x` introduced changes to configuring source maps. Accordingly, if you
 
 #### Changed options
 
-`sourceMap` - Only accepts a `Boolean` value. Generates a map with a default name for you
-`sourceMapRoot` - The location of your sources is now calculated for you when `sourceMap` is set to `true` but you can set manual source root if needed
-`sourceMappingURLBase` - Use this to prefix the automatically calculated sourceMappingURL
+`sourceMap` - Only accepts a `Boolean` value. Generates a map with a default name for you  
+`sourceMapRoot` - The location of your sources is now calculated for you when `sourceMap` is set to `true` but you can set manual source root if needed  
 
 #### New options
 
-`sourceMapName` - Accepts a string or function to change the location or name of your map
-`sourceMapIncludeSources` - Embed the content of your source files directly into the map
-`expression` - Accepts a `Boolean` value. Parse a single expression (JSON or single functions)
-`quoteStyle` - Accepts integers `0` (default), `1`, `2`, `3`. Enforce or preserve quotation mark style.
+`sourceMapName` - Accepts a string or function to change the location or name of your map  
+`sourceMapIncludeSources` - Embed the content of your source files directly into the map  
+`expression` - Accepts a `Boolean` value. Parse a single expression (JSON or single functions)  
+`sourceMappingURLBase` - Use this to prefix the automatically calculated sourceMappingURL  
+`quoteStyle` - Accepts integers `0` (default), `1`, `2`, `3`. Enforce or preserve quotation mark style.  
 
 ### Options
 
@@ -122,19 +122,19 @@ With this option you can customize root URL that browser will use when looking f
 
 If the sources are not absolute URLs after prepending of the `sourceMapRoot`, the sources are resolved relative to the source map.
 
-###### sourceMappingURLBase
-Type: `String`  
-Default: `undefined`
-
-When used, this option will add a base URL to the source maps filename (`//# sourceMappingURL=[baseURL][map-filename]`).  
-If `undefined` the relative path will be used.
-
 ###### enclose
 Type: `Object`  
 Default: `undefined`
 
 Wrap all of the code in a closure with a configurable arguments/parameters list.
 Each key-value pair in the `enclose` object is effectively an argument-parameter pair.
+
+##### sourceMappingURLBase
+Type: `String`  
+Default: `undefined`
+
+When used, this option will add a base URL to the source maps filename  
+(`//# sourceMappingURL=[baseURL][map-filename]`). If `undefined` the relative path will be used.
 
 #### wrap
 Type: `String`  

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ Version `3.x` introduced changes to configuring source maps. Accordingly, if you
 
 #### Removed options
 
-`sourceMappingURL` - This is calculated automatically now
+`sourceMappingURL` - This is calculated automatically now   
 `sourceMapPrefix` - No longer necessary for the above reason
 
 #### Changed options
 
 `sourceMap` - Only accepts a `Boolean` value. Generates a map with a default name for you
 `sourceMapRoot` - The location of your sources is now calculated for you when `sourceMap` is set to `true` but you can set manual source root if needed
+`sourceMappingURLBase` - Use this to prefix the automatically calculated sourceMappingURL
 
 #### New options
 
@@ -120,6 +121,13 @@ Default: `undefined`
 With this option you can customize root URL that browser will use when looking for sources.
 
 If the sources are not absolute URLs after prepending of the `sourceMapRoot`, the sources are resolved relative to the source map.
+
+###### sourceMappingURLBase
+Type: `String`  
+Default: `undefined`
+
+When used, this option will add a base URL to the source maps filename (`//# sourceMappingURL=[baseURL][map-filename]`).  
+If `undefined` the relative path will be used.
 
 ###### enclose
 Type: `Object`  

--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ Default: `undefined`
 Wrap all of the code in a closure with a configurable arguments/parameters list.
 Each key-value pair in the `enclose` object is effectively an argument-parameter pair.
 
-##### sourceMappingURLBase
+#### sourceMappingURLBase
 Type: `String`  
 Default: `undefined`
 
-When used, this option will add a base URL to the source maps filename  
-(`//# sourceMappingURL=[baseURL][map-filename]`). If `undefined` the relative path will be used.
+When used, this option will add a base URL to the source maps filename. If `undefined` the relative path will be used.
+
+Example: `//# sourceMappingURL=[baseURL][sourceMapFilename]`
 
 #### wrap
 Type: `String`  

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -174,10 +174,16 @@ exports.init = function(grunt) {
 
     var min = output.get();
 
+    // Replaces backslashes with forward slashes
+    // Similar to the uri-path module, but without uri-encoding and replacing multiple slashes
+    var forwardSlash = function (path) {
+      return path.replace(/\\/g, '/');
+    };
+
     // Add the source map reference to the end of the file
     if (options.sourceMap) {
       // Set all paths to forward slashes for use in the browser
-      min += '\n//# sourceMappingURL=' + uriPath(options.destToSourceMap);
+      min += '\n//# sourceMappingURL=' + forwardSlash(options.destToSourceMap);
     }
 
     var result = {

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -123,9 +123,13 @@ module.exports = function(grunt) {
       // Calculate the path from the dest file to the sourcemap for the
       // sourceMappingURL reference
       if (options.sourceMap) {
-        var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
         var sourceMapBasename = path.basename(options.generatedSourceMapName);
-        options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
+        if (options.sourceMappingURLBase) {
+          options.destToSourceMap = options.sourceMappingURLBase + sourceMapBasename;
+        } else {
+          var destToSourceMapPath = relativePath(f.dest, options.generatedSourceMapName);
+          options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
+        }
       }
 
       if (options.screwIE8) {

--- a/test/fixtures/expected/sourcemap_sourceMappingURL.js
+++ b/test/fixtures/expected/sourcemap_sourceMappingURL.js
@@ -1,0 +1,2 @@
+function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
+//# sourceMappingURL=http://localhost:8080/sourcemap_sourceMappingURL.js.map

--- a/test/fixtures/expected/sourcemap_sourceMappingURLBase.js
+++ b/test/fixtures/expected/sourcemap_sourceMappingURLBase.js
@@ -1,2 +1,2 @@
 function longFunctionC(a,b){return longNameA+longNameB+a+b}var longNameA=1,longNameB=2,result=longFunctionC(3,4);
-//# sourceMappingURL=http://localhost:8080/sourcemap_sourceMappingURL.js.map
+//# sourceMappingURL=http://localhost:8080/sourcemap_sourceMappingURLBase.js.map

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -34,6 +34,7 @@ exports.contrib_uglify = {
       'sourcemap_customRoot.js.map',
       'sourcemap_functionName.js',
       'sourcemap_functionName.js.fn.map',
+      'sourcemap_sourceMappingURL.js',
       path.join('deep', 'directory', 'location', 'source_map.js.map'),
       'sourcemapin.js',
       'sourcemapin.js.map',

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -34,7 +34,7 @@ exports.contrib_uglify = {
       'sourcemap_customRoot.js.map',
       'sourcemap_functionName.js',
       'sourcemap_functionName.js.fn.map',
-      'sourcemap_sourceMappingURL.js',
+      'sourcemap_sourceMappingURLBase.js',
       path.join('deep', 'directory', 'location', 'source_map.js.map'),
       'sourcemapin.js',
       'sourcemapin.js.map',


### PR DESCRIPTION
To enable having the sourcemap file on a different domain I added a `sourceMappingURLBase` option that will, if defined, be prepended to the map filename. 
- New `sourceMappingURLBase`-option added 
- Test added 
- Documentation (README) updated accordingly 
- Signed CLA as `marlun78`