### PR TITLE
add bare_returns option

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -44,6 +44,7 @@ exports.init = function(grunt) {
       var sourceMapDir = path.dirname(options.generatedSourceMapName);
       var relativePath = path.relative(sourceMapDir, fileDir);
       var pathPrefix = relativePath ? relativePath + path.sep : '';
+      var bare_returns = options.bare_returns || undefined;
 
       // Convert paths to use forward slashes for sourcemap use in the browser
       file = uriPath(pathPrefix + basename);
@@ -52,7 +53,8 @@ exports.init = function(grunt) {
       topLevel = UglifyJS.parse(code, {
         filename: file,
         toplevel: topLevel,
-        expression: options.expression
+        expression: options.expression,
+        bare_returns: bare_returns
       });
     });
 


### PR DESCRIPTION
I couldn't add to @pcolton's pull request for some reason (https://github.com/gruntjs/grunt-contrib-uglify/pull/310)

Here is a pull request with a single commit. Should be up to date with upstream.

PR to add support for the `--bare-return` option referenced here: https://github.com/mishoo/UglifyJS2/issues/288
and added to uglify2 here: https://github.com/mishoo/UglifyJS2/commit/f36a1eaa8b5203ab7e4616108c33a0b68668a8db
