### PR TITLE
Update uri-path dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "^3.2.0",
     "maxmin": "^1.0.0",
     "uglify-js": "^2.5.0",
-    "uri-path": "0.0.2"
+    "uri-path": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.2",


### PR DESCRIPTION
The uri-path package is now dual-licensed under WTFPL and MIT.

There are otherwise no functional changes from v0.0.2 to 1.0.0. I have bumped uri-path's version to 1.0.0 as it is already used in production and will follow semver.