### PR TITLE
Do not use "^" versions, ever, use ~

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
-    "lodash": "^3.2.0",
-    "maxmin": "^1.0.0",
-    "uglify-js": "^2.5.0",
-    "uri-path": "^1.0.0"
+    "chalk": "~1.0.0",
+    "lodash": "~3.2.0",
+    "maxmin": "~1.0.0",
+    "uglify-js": "~2.5.0",
+    "uri-path": "~1.0.0"
   },
   "devDependencies": {
-    "grunt": "^0.4.2",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-internal": "^0.4.12",
-    "grunt-contrib-jshint": "^0.11.0",
-    "grunt-contrib-nodeunit": "^0.4.0"
+    "grunt": "~0.4.2",
+    "grunt-cli": "~0.1.13",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-internal": "~0.4.12",
+    "grunt-contrib-jshint": "~0.11.0",
+    "grunt-contrib-nodeunit": "~0.4.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
Today ugilfy.js 2.6.0 broke everything in our setup, we can not go back to an older version, because you specified ^2.5.0.