### PR TITLE
add handling of mangle_properties regex option in uglifyjs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -327,6 +327,16 @@ module.exports = function(grunt) {
           nameCache: 'tmp/uglify_name_cache.json'
         }
       },
+      mangleprops_withRegex: {
+        files: {
+          'tmp/mangleprops_withRegex.js': ['test/fixtures/src/mangleprops_withRegex.js']
+        },
+        options: {
+          mangleProperties: {
+            regex: /^[^#].*/
+          }
+        }
+      },
       quotes_single: {
         files: {
           'tmp/quotes_single.js': ['test/fixtures/src/quotes.js']

--- a/docs/uglify-options.md
+++ b/docs/uglify-options.md
@@ -135,10 +135,10 @@ Default: `false`
 Pass this flag if you don't care about full compliance with Internet Explorer 6-8 quirks.
 
 ## mangleProperties
-Type: `Boolean`  
+Type: `Boolean` `Object`
 Default: `false`
 
-Use this flag to turn on object property name mangling.
+Turn on or off property mangling with default options. If an `Object` is specified, it is passed directly to `ast.mangle_properties()` (mimicking command line behavior). [View all options here](https://github.com/mishoo/UglifyJS2#mangler-options).
 
 ## reserveDOMProperties
 Type: `Boolean`  

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -117,11 +117,16 @@ exports.init = function(grunt) {
       cache = UglifyJS.readNameCache(options.nameCache, 'props');
     }
 
-    if (options.mangleProperties === true) {
-      topLevel = UglifyJS.mangle_properties(topLevel, {
-        reserved: mangleExclusions ? mangleExclusions.props : null,
-        cache: cache
-      });
+    if (typeof(options.mangleProperties) !== 'undefined' && options.mangleProperties !== false) {
+      // if options.mangleProperties is a boolean (true) convert it into an object
+      if (typeof options.mangleProperties !== 'object') {
+        options.mangleProperties = {};
+      }
+
+      options.mangleProperties.reserved = mangleExclusions ? mangleExclusions.props : null;
+      options.mangleProperties.cache = cache;
+
+      topLevel = UglifyJS.mangle_properties(topLevel, options.mangleProperties);
 
       if (options.nameCache) {
         UglifyJS.writeNameCache(options.nameCache, 'props', cache);
@@ -257,7 +262,7 @@ exports.init = function(grunt) {
     if (!_.isUndefined(options.preserveComments)) {
       outputOptions.comments = options.preserveComments;
     }
-    
+
     return outputOptions;
   };
 

--- a/test/fixtures/expected/mangleprops_withRegex.js
+++ b/test/fixtures/expected/mangleprops_withRegex.js
@@ -1,0 +1,1 @@
+var anObject={a:"val","#key2":"val2"};

--- a/test/fixtures/src/mangleprops_withRegex.js
+++ b/test/fixtures/src/mangleprops_withRegex.js
@@ -1,0 +1,4 @@
+var anObject = {
+  key1: 'val',
+  '#key2': 'val2'
+};

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -56,6 +56,7 @@ exports.contrib_uglify = {
       'mangleprops_withExceptAndExceptionsFiles.js',
       'mangleprops_withNameCacheFile1.js',
       'mangleprops_withNameCacheFile2.js',
+      'mangleprops_withRegex.js',
       'uglify_name_cache.json',
       'quotes_single.js',
       'quotes_double.js',


### PR DESCRIPTION
The uglifyjs tool now allows for specifying regexes when mangling properties. This PR adds wrapper functionality for the feature.