### PR TITLE
Fix screw ie8 option crash

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -88,6 +88,9 @@ exports.init = function(grunt) {
       if (options.compress.warnings !== true) {
         options.compress.warnings = false;
       }
+      if (options.screwIE8) {
+        options.compress.screw_ie8 = true;
+      }
       var compressor = UglifyJS.Compressor(options.compress);
       topLevel = topLevel.transform(compressor);
 
@@ -134,6 +137,12 @@ exports.init = function(grunt) {
     }
 
     if (options.mangle !== false) {
+      if (options.mangle === true) {
+        options.mangle = {};
+      }
+      if (options.screwIE8) {
+        options.mangle.screw_ie8 = true;
+      }
       // disabled due to:
       //   1) preserve stable name mangling
       //   2) it increases gzipped file size, see https://github.com/mishoo/UglifyJS2#mangler-options

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -128,11 +128,6 @@ module.exports = function(grunt) {
         options.destToSourceMap = destToSourceMapPath + sourceMapBasename;
       }
 
-      if (options.screwIE8) {
-        if (options.mangle) { options.mangle.screw_ie8 = true; }
-        if (options.compress) { options.compress.screw_ie8 = true; }
-      }
-
       // Minify files, warn and fail on error.
       var result;
       try {


### PR DESCRIPTION
Just checking if the build fails because of this commit alone by merging with current master.

Should close #303 and #311 if there are no problems with the patch.