### PR TITLE
Improve documentation for conditional compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,9 +414,9 @@ grunt.initConfig({
 
 #### Conditional compilation
 
-You can also enable UglifyJS conditional compilation. This is commonly used to remove debug code blocks for production builds.
+You can also enable UglifyJS conditional compilation . This is commonly used to remove debug code blocks for production builds.
 
-See [UglifyJS global definitions documentation](http://lisperator.net/uglifyjs/compress#global-defs) for more information.
+See [UglifyJS global definitions documentation](http://lisperator.net/uglifyjs/compress#global-defs) for more information. This is equivalent to the command line [`--define` option](https://github.com/mishoo/UglifyJS#use-as-a-code-pre-processor).
 
 ```js
 // Project configuration.


### PR DESCRIPTION
Having read uglifyjs' documentation, I came to this repo looking for how to use the equivalent of the `--define` command line option. I almost was unable to find how to do so, but #12 saved me, indicating that the documentation was just not great on how to use this feature.

So this change would hopefully just help people like me who searched the page for `--define` and didn't know what to do when they couldn't find it.