### PR TITLE
Use uglify-js ~2.6.2 to fix sourcemap issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chalk": "^1.0.0",
     "lodash": "^4.0.1",
     "maxmin": "^2.0.0",
-    "uglify-js": "~2.6.0",
+    "uglify-js": "~2.6.2",
     "uri-path": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to https://github.com/mishoo/UglifyJS2/issues/882

UglifyJS had an error with sourcemapping where passing in a sourcemap and JS file wouldn't output the correct sourcemap.

That error was fixed with https://github.com/mishoo/UglifyJS2/pull/966 and then UglifyJS version number was bumped to 2.6.2 after.

We should specify the version of `uglify-js` to be `~2.6.2` so that the buggy version isn't installed or referenced.

Could also be related to #266, #376, and #343.