### PR TITLE
We need to manually add gzip-size since maxmin uses 3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
+    "gzip-size": "2.1.0",
     "lodash": "^4.0.1",
     "maxmin": "^2.0.0",
     "uglify-js": "~2.6.2",


### PR DESCRIPTION
This fixes an issue where by it fails on nodejs 0.10 because maxmin uses version 3 of gzip-size which droped support for nodejs 0.10 so to work around this we include it manually.