### PR TITLE
Added quiet mode

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -187,8 +187,9 @@ module.exports = function(grunt) {
       }
 
       var outputSize = maxmin(result.max, output, options.report === 'gzip');
+      if(!options.quiet){
       log.writeln('File ' + chalk.cyan(f.dest) + ' created: ' + outputSize);
-
+      }
       createdFiles++;
     });
 


### PR DESCRIPTION
Added optional flag inside options for suppressing the logging.

Adding such a option only affects the logging, precisely **grunt.log.writeln**.
It doesn't affect any other thing. Still, the tests fail.