### PR TITLE
Used grunt.verbose to show detailed logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ grunt.initConfig({
   }
 });
 ```
+#### Quiet Mode
+By default the task supresses the logging, use _--verbose_ to show the full output.
 
 
 ## Release History

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -24,20 +24,6 @@ function relativePath(file1, file2) {
   return '';
 }
 
-function reportFacility( grunt, options ){
-  var reporter;
-  switch( options.report ){
-    case 'none':
-      reporter = grunt.verbose;
-      break;
-    default:
-    case 'min':
-    case 'gzip':
-      reporter = grunt.log;
-  }
-  return reporter;
-}
-
 // Converts \r\n to \n
 function normalizeLf(string) {
   return string.replace(/\r\n/g, '\n');
@@ -64,7 +50,6 @@ module.exports = function(grunt) {
       screwIE8: false,
       quoteStyle: 0
     });
-    var log = reportFacility( grunt, options );
 
     // Process banner.
     var banner = normalizeLf(options.banner);
@@ -182,12 +167,12 @@ module.exports = function(grunt) {
       // Write source map
       if (options.sourceMap) {
         grunt.file.write(options.generatedSourceMapName, result.sourceMap);
-        log.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
+        grunt.verbose.writeln('File ' + chalk.cyan(options.generatedSourceMapName) + ' created (source map).');
         createdMaps++;
       }
 
       var outputSize = maxmin(result.max, output, options.report === 'gzip');
-      log.writeln('File ' + chalk.cyan(f.dest) + ' created: ' + outputSize);
+      grunt.verbose.writeln('File ' + chalk.cyan(f.dest) + ' created: ' + outputSize);
 
       createdFiles++;
     });


### PR DESCRIPTION
Use grunt.verbose to show detailed logging.
Made the task quiet by default. Will only show _**x** files created_ at the end without _--verbose_