### PR TITLE
Update docs for preserveComments (CI failure appears unrelated)

### DIFF
--- a/docs/uglify-examples.md
+++ b/docs/uglify-examples.md
@@ -59,6 +59,24 @@ grunt.initConfig({
 });
 ```
 
+## Retain comments with `!` or preservation directives
+
+A common use case is to retain comments starting with `!` or with preserve directives, but strip all others. To do this, use `preserveComments` with the `Function` option, eg:
+ 
+    uglify: {
+      options: {
+        preserveComments: function(node, comment) {
+          return /^!|@preserve|@license|@cc_on/i.test(comment.value);
+        }
+      },
+      build: {
+        src: 'example.js',
+        dest: 'example.min.js'
+      }
+    }
+
+Note: this was previously replicated with `some`, but this option has been removed.
+
 ## Source maps
 
 Generate a source map by setting the `sourceMap` option to `true`. The generated

--- a/docs/uglify-options.md
+++ b/docs/uglify-options.md
@@ -112,15 +112,14 @@ Default: `false`
 When using `wrap` this will make all global functions and variables available via the export variable.
 
 ## preserveComments
-Type: `Boolean` `String` `Function`  
+Type: `Boolean` `Function`  
 Default: `undefined`  
-Options: `false` `'all'` `'some'`
+Options: `true` `false` `Function`
 
-Turn on preservation of comments.
+Turn on preservation of comments. Note some Uglify command line options are not available, see Examples for details on preserving some comments but stripping others.
 
 - `false` will strip all comments
-- `'all'` will preserve all comments in code blocks that have not been squashed or dropped
-- `'some'` will preserve all comments that start with a bang (`!`) or include a closure compiler style directive (`@preserve` `@license` `@cc_on`)
+- `true` will preserve all comments in code blocks that have not been squashed or dropped
 - `Function` specify your own comment preservation function. You will be passed the current node and the current comment and are expected to return either `true` or `false`
 
 ## banner


### PR DESCRIPTION
- Removed old options `some` and `all`
- Added example on how to replicate license preservation (that `some` used to cover)
