### PR TITLE
Added harmony branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chalk": "^1.0.0",
     "maxmin": "^1.1.0",
     "object.assign": "^4.0.4",
-    "uglify-js": "~2.7.0",
+    "uglify-js": "https://github.com/mishoo/UglifyJS2.git#harmony",
     "uri-path": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Added a new branch with the harmony version, so we can include in our package.json just `"grunt-contrib-uglify": "https://github.com/gruntjs/grunt-contrib-uglify.git#harmony"` instead of having to clone and maintain it locally.