### PR TITLE
Upgrade to uglify-es 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "maxmin": "^1.1.0",
-    "uglify-es": "~3.0.4",
+    "uglify-es": "~3.0.5",
     "uri-path": "^1.0.0"
   },
   "devDependencies": {

--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -94,7 +94,7 @@ exports.init = function(grunt) {
           minifyOptions.mangle.properties.reserved = [];
         }
         if (options.reserveDOMProperties) {
-          require('uglify-js/tools/domprops').forEach(function(name) {
+          require('uglify-es/tools/domprops').forEach(function(name) {
             UglifyJS._push_uniq(minifyOptions.mangle.properties.reserved, name);
           });
         }


### PR DESCRIPTION
@XhmikosR This should fix the test failure on `harmony`.

Also fix an issue with `reserveDOMProperties` which would have erred out before.