### PR TITLE
Throwing error and exiting if 'nonull' option is set and file doesn't exist.

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -37,8 +37,7 @@ module.exports = function(grunt) {
   var getAvailableFiles = function (filesArray) {
     return filesArray.filter(function (filepath) {
       if (!grunt.file.exists(filepath)) {
-        grunt.log.warn('Source file ' + chalk.cyan(filepath) + ' not found');
-        return false;
+        throw new Error('Source file ' + chalk.cyan(filepath) + ' not found');
       }
       return true;
     });


### PR DESCRIPTION
See #160, specifically starting with [this comment](https://github.com/gruntjs/grunt-contrib-uglify/issues/160#issuecomment-72775083).

If the user passes in the `nonull` option, I think it makes sense for the grunt task to error when a file doesn't exist. Note that this doesn't change the existing behavior when nonull is not set.