### PR TITLE
handle minification failure gracefully

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -412,6 +412,14 @@ module.exports = function(grunt) {
             max_line_len: 55
           }
         }
+      },
+      fail_to_minify: {
+        options: {
+          skipErrors: true
+        },
+        files: {
+          'tmp/fail_to_minify.js': ['test/fixtures/src/fail_to_minify.js']
+        }
       }
     },
 

--- a/test/fixtures/expected/fail_to_minify.js
+++ b/test/fixtures/expected/fail_to_minify.js
@@ -1,0 +1,8 @@
+// Ideally this comment should get removed
+
+function failToMinify() {
+  var @@name = 1;
+}
+
+
+/* This too */

--- a/test/fixtures/src/fail_to_minify.js
+++ b/test/fixtures/src/fail_to_minify.js
@@ -1,0 +1,8 @@
+// Ideally this comment should get removed
+
+function failToMinify() {
+  var @@name = 1;
+}
+
+
+/* This too */

--- a/test/uglify_test.js
+++ b/test/uglify_test.js
@@ -21,6 +21,7 @@ exports.contrib_uglify = {
       'compress_mangle_banner.js',
       'compress_mangle_beautify.js',
       'compress_mangle_except.js',
+      'fail_to_minify.js',
       'multifile.js',
       'wrap.js',
       'maxLineLen.js',


### PR DESCRIPTION
Fixes: https://github.com/gruntjs/grunt-contrib-uglify/issues/409

Whenever the minification of a file fails, the task fails with the
error 'min' is not available in 'undefined'.

This patch allows the task to continue to the next file without
making any changes to the contents of the file in the destination.
Also, this introduces a new configuration option `skipErrors`, so
that the users can specify that in the task level options to override
the default behaviour.