### PR TITLE
Update uglify-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3700,9 +3700,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
-      "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig=="
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg=="
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "maxmin": "^2.1.0",
-    "uglify-js": "^3.13.3",
+    "uglify-js": "^3.13.10",
     "uri-path": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/gruntjs/grunt-contrib-uglify/issues/553 (supported in v3.13.6)

Many other improvements and fixes.

Maybe it would be worth to use a bot to update dependencies?