### PR TITLE
Pass `webkit` flag down to UglifyJS

### DIFF
--- a/tasks/lib/uglify.js
+++ b/tasks/lib/uglify.js
@@ -51,7 +51,8 @@ exports.init = function(grunt) {
       parse: options.parse || {},
       sourceMap: options.sourceMap,
       toplevel: options.toplevel,
-      wrap: options.wrap
+      wrap: options.wrap,
+      webkit: options.webkit
     };
 
     if (options.banner) {


### PR DESCRIPTION
**UglifyJS 3** supports the following flag, which fixes some issues on Safari:
```
webkit (default: false) — enable workarounds for Safari/WebKit bugs. PhantomJS users should set this option to true
```
Currently `grunt-contrib-uglify` ignores this option when constructing `minifyOptions` for UglifyJS; this PR fixes that.